### PR TITLE
💄 Design: 공통 Header 컴포넌트

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,6 @@ const App = () => {
       <ThemeProvider theme={theme}>
         <GlobalStyles />
         <Layout>
-          {/* TODO : Header Component 추가  */}
           <StyledBox>
             <Outlet />
           </StyledBox>

--- a/src/assets/ico_back.svg
+++ b/src/assets/ico_back.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 18L9 12L15 6" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/ico_close.svg
+++ b/src/assets/ico_close.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 6L6 18M6 6L18 18" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -1,0 +1,50 @@
+import { styled } from 'styled-components';
+
+import { HEADER_LEFT_ICONS } from '@/constants/commonUiData';
+
+type LeftIconType = "back" | "close" | "none";
+
+type THeaderProps = {
+  leftIcon?: LeftIconType;      // 왼쪽 버튼 타입
+  leftIconClick?: () => void;   // 왼쪽 버튼 클릭 콜백 함수
+  title?: string;               // 타이틀
+};
+
+const Header = ({ leftIcon = "none", leftIconClick, title }: THeaderProps) => {
+  return (
+    <StyledHeader>
+      <StyledLeftIcon onClick={leftIconClick}>
+        {
+          leftIcon !== "none" && <img src={HEADER_LEFT_ICONS[leftIcon]} alt="" />
+        }
+      </StyledLeftIcon>
+      <StyledTtile>
+        {title}
+      </StyledTtile>
+    </StyledHeader>
+  );
+};
+
+const StyledHeader = styled.header`
+  height: 56px;
+  font-size: 18px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  padding: 16px 18px;
+`;
+
+const StyledLeftIcon = styled.div`
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+`;
+
+const StyledTtile = styled.div`
+  flex-grow: 1;
+  text-align: center;
+  margin-right: 24px;
+`;
+
+
+export default Header;

--- a/src/constants/commonUiData.ts
+++ b/src/constants/commonUiData.ts
@@ -1,0 +1,8 @@
+import IconBack from '@/assets/ico_back.svg';
+import IconClose from '@/assets/ico_close.svg';
+
+export const HEADER_LEFT_ICONS = {
+  back: IconBack,
+  close: IconClose,
+  none: null
+};

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,8 +1,16 @@
+import { styled } from "styled-components";
+
 const Home = () => {
-  
+
   return (
-    <div>Home</div>
+    <StyledLayout>
+
+    </StyledLayout>
   );
 };
+
+const StyledLayout = styled.div`
+  
+`;
 
 export default Home;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,7 @@
       "constants/*": ["src/constants/*"],
       "stores/*": ["src/stores/*"],
       "styles/*": ["src/styles/*"],
+      "assets/*": ["src/assets/*"],
     }
   },
   "include": ["src", "src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.d.ts"], //컴파일할 파일 경로 목록


### PR DESCRIPTION
### 📌 개요

기본 레이아웃 구성에 이슈가 있어서 수정하여 반영합니다.
추가적으로 Header 작업이 완료된 상태라서 같이 반영되었습니다.

### 📝 기타사항

![image](https://github.com/FC-Chilli-Bubble/front-officener/assets/108085046/17690f70-21b8-4dfa-b2ea-57766f5da388)

Router를 보시면 위와 같이 Navigation이 있으면 NavLayout의 하위로 들어가고, 없으면 Layout의 하위로 들어가게 됩니다.
