### PR TITLE
[Fix]:로그인 인증 에러 처리 : 토큰만료401 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { Outlet } from 'react-router-dom';
-import { RecoilRoot } from 'recoil';
+// import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from 'styled-components';
 import { CookiesProvider } from 'react-cookie';
 
@@ -14,7 +14,7 @@ const App = () => {
 
   return (
     <>
-      <RecoilRoot>
+      
         <CookiesProvider>
           <ThemeProvider theme={theme}>
             <GlobalStyles />
@@ -22,7 +22,7 @@ const App = () => {
             <Modal />
           </ThemeProvider>
         </CookiesProvider>
-      </RecoilRoot>
+      
     </>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { Outlet } from 'react-router-dom';
-// import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from 'styled-components';
 import { CookiesProvider } from 'react-cookie';
 
@@ -14,7 +13,6 @@ const App = () => {
 
   return (
     <>
-      
         <CookiesProvider>
           <ThemeProvider theme={theme}>
             <GlobalStyles />

--- a/src/constants/modalDatas.ts
+++ b/src/constants/modalDatas.ts
@@ -64,6 +64,11 @@ const MODAL_DATAS = {
     title: '함께배달',
     content: '게시글 조회를 실패했습니다\n다시 시도해주세요',
     positive: '확인'
+  },
+  SESSION_EXPIRATION_ALERT: {
+    title: '로그인 세션 만료',
+    content: '로그인 세션이 만료되었습니다.\n다시 로그인해주세요.',
+    positive: '확인'
   }
 };
 

--- a/src/hooks/useAxiosInterceptor.tsx
+++ b/src/hooks/useAxiosInterceptor.tsx
@@ -1,19 +1,41 @@
 import { useEffect } from 'react';
 import { AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { useCookies } from 'react-cookie';
+import { useResetRecoilState } from 'recoil';
+import { useNavigate } from 'react-router-dom';
 
-import { apiClient } from "@/apis/apiClient";
+import { apiClient } from '@/apis/apiClient';
 import { IErrorResponse } from '@/types/Common/IErrorResponse';
+import { userInfoAtom } from '@/states/userDataAtom';
+import { useModal } from '@/hooks/useModal';
 
+import MODAL_DATAS from '@/constants/modalDatas';
 const useAxiosInterceptor = () => {
-  const [cookies] = useCookies(['token']);
-  const accessToken = cookies.token || ''; // TODO : 쿠키에 저장된 토큰 값
+  const { openModal } = useModal();
+  const [cookies, removeCookie] = useCookies(['token']);
+  const accessToken = cookies.token || ''; // 쿠키에 저장된 토큰 값
+  const clearUser = useResetRecoilState(userInfoAtom);
+  const navigate = useNavigate();
 
   // 응답 공통 에러 처리
-  const handleError = (error: AxiosError) => {
+  const handleError = async (error: AxiosError) => {
     // TODO : 401 인증 에러 처리 추가 필요
+    if (error.response?.status === 401 && error.config?.url !== '/login') {
+      // 로그인 세션 만료 팝업
+      openModal({
+        ...MODAL_DATAS.SESSION_EXPIRATION_ALERT,
+        positiveCallback: () => {
+          clearUser(); // 리코일 유저 정보 삭제
+          removeCookie('token', { path: '/' });
+          navigate('/login', { replace: true });
+          // 스택 초기화 추가 작성 필요
+        }
+      });
+    }
     // TODO : 인증 에러 시 로그아웃 처리
-    return Promise.reject<IErrorResponse>(error.response?.data as IErrorResponse || { errorMessage: error.message });
+    return Promise.reject<IErrorResponse>(
+      (error.response?.data as IErrorResponse) || { errorMessage: error.message }
+    );
   };
 
   const authConfig = (config: InternalAxiosRequestConfig<unknown>) => {
@@ -38,7 +60,6 @@ const useAxiosInterceptor = () => {
       apiClient.interceptors.response.eject(responseInterceptor);
     };
   }, [responseInterceptor, requestInterceptor]);
-
 };
 
 export default useAxiosInterceptor;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,12 @@
 import ReactDOM from 'react-dom/client';
-import { RouterProvider, } from 'react-router-dom';
-
+import { RouterProvider } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
 import { router } from '@/utils/Router';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <>
-    <RouterProvider router={router} />
+    <RecoilRoot>
+      <RouterProvider router={router} />
+    </RecoilRoot>
   </>
 );

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -136,7 +136,7 @@ const Login = () => {
             setCookie('token', token, { path: '/' });
           }
           setUser(userInfo);
-          navigate('/');
+          navigate('/', { replace: true });
         },
         (error: IErrorResponse) => {
           setEmailErrorIcon('wrong');


### PR DESCRIPTION
### 📌 개요
<!-- PR과 관련있는 Issue를 closed 해주세요 -->
closed #52(로그아웃 완료 후 닫기)

### ✅ 작업사항
로그인 세션 만료 에러 처리 (401 ERROR)
 - 토큰 기한 만료 시 토큰이 필요한 기능 이용 할 때 세션만료 안내 모달 추가.
 - 사용자 정보  & 토큰 리셋
 - 로그인 페이지로 이동 -> 로그인해서 토큰 재발급 시도
 - 로그인 페이지로 이동 시 replace사용(뒤로 가기 방지)
 - `useAxiosInterceptor.tsx` 파일의 21번째 줄 함수 코드 참고
 
![image](https://github.com/FC-Chilli-Bubble/front-officener/assets/66905959/a603dc65-11de-4204-ac7a-4cc50f4d6438)



### 📝 기타사항
- 이후에 리프레시 토큰 사용하게 될 경우 에러처리 코드 업데이트 예정