### PR TITLE
:but:FIX: 회원가입 유효성 검사 수정_버튼 동기적으로 전환

### DIFF
--- a/src/components/Signup/SignupStep5.tsx
+++ b/src/components/Signup/SignupStep5.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import { EMAIL_REGEX, PASSWORD_REGEX } from '@/constants/regexp';
 import { useSetRecoilState } from 'recoil';
@@ -61,7 +61,8 @@ const SignupStep5 = ({ onNextStep }: SignupStepProps) => {
       return;
     } else {
       setEmailErrorIcon('none');
-      setEmailMsg('');
+      setEmailMsg('pass');
+      handleIsValid();
     }
   };
 
@@ -80,7 +81,7 @@ const SignupStep5 = ({ onNextStep }: SignupStepProps) => {
       return;
     } else {
       setEmailErrorIcon('none');
-      setEmailMsg('');
+      setEmailMsg('pass');
       handleIsValid();
     }
   };
@@ -98,6 +99,10 @@ const SignupStep5 = ({ onNextStep }: SignupStepProps) => {
       setPwdMsg('');
       setIsValid(false);
       return;
+    } else if (newPassword === passwordVerify) {
+      setPwsErrorIcon('correct');
+      setPwdMsg('비밀번호가 일치합니다.');
+      return;
     } else {
       setPwsErrorIcon('none');
       setPwdMsg('');
@@ -114,6 +119,10 @@ const SignupStep5 = ({ onNextStep }: SignupStepProps) => {
     } else if (!PASSWORD_REGEX.test(newPassword)) {
       setPwsErrorIcon('error');
       setPwdMsg('8~16자의 영문, 숫자, 특수문자를 모두 포함한 비밀번호를 입력해주세요');
+      return;
+    } else if (newPassword === passwordVerify) {
+      setPwsErrorIcon('correct');
+      setPwdMsg('비밀번호가 일치합니다.');
       return;
     } else {
       setPwdMsg('');
@@ -139,7 +148,7 @@ const SignupStep5 = ({ onNextStep }: SignupStepProps) => {
     } else {
       setPwsErrorIcon('correct');
       setPwdMsg('비밀번호가 일치합니다.');
-      // handleIsValid();
+      handleIsValid();
       return;
     }
   };
@@ -150,31 +159,36 @@ const SignupStep5 = ({ onNextStep }: SignupStepProps) => {
     if (!newPassword) {
       setPwsErrorIcon('error');
       setPwdMsg('비밀번호를 다시 입력해 주세요');
-      // setIsValid(false);
       return;
     } else if (password !== newPassword) {
       setPwsErrorIcon('error');
       setPwdMsg('비밀번호가 일치하지 않습니다.');
-      // setIsValid(false);
       return;
     } else if (!PASSWORD_REGEX.test(newPassword)) {
       setPwsErrorIcon('error');
       setPwdMsg('8~16자의 영문, 숫자, 특수문자를 모두 포함한 비밀번호를 입력해주세요');
-      // setIsValid(false);
       return;
     } else {
       setPwsErrorIcon('correct');
       setPwdMsg('비밀번호가 일치합니다.');
+      handleIsValid();
       return;
     }
   };
 
   const handleIsValid = () => {
-    if (!emailMsg && pwsErrorIcon === 'correct') {
+    if (emailMsg === 'pass' && pwsErrorIcon === 'correct') {
       setIsValid(true);
       return;
+    } else {
+      setIsValid(false);
     }
   };
+
+  // passwordVerify 상태 변경 시 handleIsValid 호출
+  useEffect(() => {
+    handleIsValid();
+  }, [email, passwordVerify, password, emailMsg, pwdMsg]);
 
   // 계정 생성(저장))
   const handleAccountSubmit = (e: React.FormEvent<HTMLFormElement>) => {

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -108,7 +108,7 @@ const Login = () => {
           setCookie('token', token, { path: '/' });
         }
         setUser(userInfo);
-        navigate('/', { replace: true });
+        navigate('/intro', { replace: true });
       },
       (error: IErrorResponse) => {
         if (!password) {


### PR DESCRIPTION
### 📌 개요
<!-- PR과 관련있는 Issue를 closed 해주세요 -->
closed #0

![image](https://github.com/FC-Chilli-Bubble/front-officener/assets/66905959/f6923641-48b4-45de-9256-cb4448053562)

### ✅ 작업사항

- 회원가입 시 발생하는 유효성 에러 수정했습니다. 
  1) 이메일 -> 비밀번호  혹은 비밀번호 -> 이메일 순서로 입력시에도  입력양식에 맞게 작성되면 버튼이 활성화 됩니다.
      ( 포커스 아웃 하지 않아도 감지하도록 함)
  2)  '비밀번호 재확인 '통과 후 비밀번호를 임의로 수정해도 다음페이지로 이동되는 부분도 수정되었습니다.

